### PR TITLE
Fixed System.FormatException and little updated cli example

### DIFF
--- a/AddressablesTools/Catalog/ContentCatalogData.cs
+++ b/AddressablesTools/Catalog/ContentCatalogData.cs
@@ -184,8 +184,13 @@ namespace AddressablesTools.Catalog
                     int splitIndex = internalId.IndexOf('#');
                     if (splitIndex != -1)
                     {
-                        int prefixIndex = int.Parse(internalId[..splitIndex]);
-                        internalId = string.Concat(InternalIdPrefixes[prefixIndex], internalId.AsSpan(splitIndex + 1));
+                        string subPath = internalId[..splitIndex];
+                        // check if first path before # is number
+                        int prefixIndex;
+                        if (int.TryParse(subPath, out prefixIndex))
+                        {
+                            internalId = string.Concat(InternalIdPrefixes[prefixIndex], internalId.AsSpan(splitIndex + 1));
+                        }
                     }
 
                     string providerId = ProviderIds[providerIndex];


### PR DESCRIPTION
Fixed #10 and https://github.com/nesrak1/AddressablesTools/issues/6#issuecomment-3020171216 
Some catalog.json might have path like this:
`"{UnityEngine.AddressableAssets.Addressables.RuntimePath}\\StandaloneWindows64\\build#demo_assets_all.bundle",`
and we are trying to parse it before `#` as a number this PRs handle this case.